### PR TITLE
233 model results refactor

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -86,3 +86,9 @@ export const LOGIN_FORM_INITIAL_VALUES = {
   email: "",
   password: "",
 };
+
+export const MODEL_TYPES = {
+  THOMAS: "Modelo de Thomas",
+  ADAMS_BOHART: "Modelo de Adams-Bohart",
+  YOON_NELSON: "Modelo de Yoon-Nelson",
+};

--- a/src/components/ChemicalModels/Results/AdamsBohartResults.jsx
+++ b/src/components/ChemicalModels/Results/AdamsBohartResults.jsx
@@ -1,0 +1,57 @@
+import {Results} from "../Models/Results";
+import {AdamsBohartInputFields} from "../Models/AdamsBohartInputFields";
+import {ButtonWrapper, DataFrame, Title} from "../Models/ModelsStyles";
+import {AdamsBohartResultFields} from "../Models/AdamsBohartResultFields";
+import {AdamsBohartModelPlot} from "../Models/Plots/AdamsBohartModelPlot";
+import {Button} from "../../Button/Button";
+import React from "react";
+import {adamsBohartCofficients, generateEquation} from "../Models/equations";
+
+const adamsEquation = (data) => {
+  const template = `$$\\frac{C}{C0} = e^{firstV_{ef}-second}$$`;
+  return generateEquation(template, adamsBohartCofficients(data));
+};
+
+export const AdamsBohartResults = ({
+  inputValues,
+  responses,
+  onClick,
+  colors,
+}) => {
+  return (
+    <>
+      <Results
+        inputFields={
+          <AdamsBohartInputFields
+            F={inputValues.caudalVolumetrico}
+            C0={inputValues.concentracionInicial}
+            Z={inputValues.alturaLechoReactor}
+            U0={inputValues.velocidadLineal}
+          />
+        }
+        resultsInfo={responses.map((response, index) => (
+          <DataFrame key={index}>
+            <Title color={colors[index % colors.length]}>
+              Resultados gráfico {++index}
+            </Title>
+            <AdamsBohartResultFields
+              Kab={response.Kab}
+              N0={response.N0}
+              R2={response.R2}
+              equation={adamsEquation(response)}
+            />
+          </DataFrame>
+        ))}
+        plot={
+          <AdamsBohartModelPlot
+            points={responses.map((response) => response.points)}
+            expressions={responses}
+          />
+        }
+      />
+      <ButtonWrapper>
+        <Button size="medium" text="Volver a graficar" onClick={onClick} />
+      </ButtonWrapper>
+    </>
+  );
+};

--- a/src/components/ChemicalModels/Results/AdamsBohartResults.jsx
+++ b/src/components/ChemicalModels/Results/AdamsBohartResults.jsx
@@ -1,9 +1,8 @@
 import {Results} from "../Models/Results";
 import {AdamsBohartInputFields} from "../Models/AdamsBohartInputFields";
-import {ButtonWrapper, DataFrame, Title} from "../Models/ModelsStyles";
+import {DataFrame, Title} from "../Models/ModelsStyles";
 import {AdamsBohartResultFields} from "../Models/AdamsBohartResultFields";
 import {AdamsBohartModelPlot} from "../Models/Plots/AdamsBohartModelPlot";
-import {Button} from "../../Button/Button";
 import React from "react";
 import {adamsBohartCofficients, generateEquation} from "../Models/equations";
 
@@ -12,46 +11,36 @@ const adamsEquation = (data) => {
   return generateEquation(template, adamsBohartCofficients(data));
 };
 
-export const AdamsBohartResults = ({
-  inputValues,
-  responses,
-  onClick,
-  colors,
-}) => {
+export const AdamsBohartResults = ({inputValues, responses, colors}) => {
   return (
-    <>
-      <Results
-        inputFields={
-          <AdamsBohartInputFields
-            F={inputValues.caudalVolumetrico}
-            C0={inputValues.concentracionInicial}
-            Z={inputValues.alturaLechoReactor}
-            U0={inputValues.velocidadLineal}
+    <Results
+      inputFields={
+        <AdamsBohartInputFields
+          F={inputValues.caudalVolumetrico}
+          C0={inputValues.concentracionInicial}
+          Z={inputValues.alturaLechoReactor}
+          U0={inputValues.velocidadLineal}
+        />
+      }
+      resultsInfo={responses.map((response, index) => (
+        <DataFrame key={index}>
+          <Title color={colors[index % colors.length]}>
+            Resultados gráfico {++index}
+          </Title>
+          <AdamsBohartResultFields
+            Kab={response.Kab}
+            N0={response.N0}
+            R2={response.R2}
+            equation={adamsEquation(response)}
           />
-        }
-        resultsInfo={responses.map((response, index) => (
-          <DataFrame key={index}>
-            <Title color={colors[index % colors.length]}>
-              Resultados gráfico {++index}
-            </Title>
-            <AdamsBohartResultFields
-              Kab={response.Kab}
-              N0={response.N0}
-              R2={response.R2}
-              equation={adamsEquation(response)}
-            />
-          </DataFrame>
-        ))}
-        plot={
-          <AdamsBohartModelPlot
-            points={responses.map((response) => response.points)}
-            expressions={responses}
-          />
-        }
-      />
-      <ButtonWrapper>
-        <Button size="medium" text="Volver a graficar" onClick={onClick} />
-      </ButtonWrapper>
-    </>
+        </DataFrame>
+      ))}
+      plot={
+        <AdamsBohartModelPlot
+          points={responses.map((response) => response.points)}
+          expressions={responses}
+        />
+      }
+    />
   );
 };

--- a/src/components/ChemicalModels/Results/ModelResults.jsx
+++ b/src/components/ChemicalModels/Results/ModelResults.jsx
@@ -4,10 +4,18 @@ import {YoonNelsonResults} from "./YoonNelsonResults";
 import React from "react";
 import {appColors} from "../../../common/styles";
 import {MODEL_TYPES} from "../../../common/constants";
+import {ButtonWrapper} from "../Models/ModelsStyles";
+import {Button} from "../../Button/Button";
 
-export const ModelResults = ({inputValues, responses, onClick, modelType}) => {
+export const ModelResults = ({
+  inputValues,
+  responses,
+  onClick,
+  modelType,
+  buttonText,
+}) => {
   const colors = [appColors.primary, appColors.red, appColors.green];
-
+  buttonText = buttonText || "Volver a graficar";
   const components = {
     [MODEL_TYPES.THOMAS]: ThomasResults,
     [MODEL_TYPES.ADAMS_BOHART]: AdamsBohartResults,
@@ -15,11 +23,15 @@ export const ModelResults = ({inputValues, responses, onClick, modelType}) => {
   };
   const ResultComponent = components[modelType];
   return (
-    <ResultComponent
-      inputValues={inputValues}
-      responses={responses}
-      onClick={onClick}
-      colors={colors}
-    />
+    <>
+      <ResultComponent
+        inputValues={inputValues}
+        responses={responses}
+        colors={colors}
+      />
+      <ButtonWrapper>
+        <Button size="medium" text={buttonText} onClick={onClick} />
+      </ButtonWrapper>
+    </>
   );
 };

--- a/src/components/ChemicalModels/Results/ModelResults.jsx
+++ b/src/components/ChemicalModels/Results/ModelResults.jsx
@@ -1,0 +1,25 @@
+import {ThomasResults} from "./ThomasResults";
+import {AdamsBohartResults} from "./AdamsBohartResults";
+import {YoonNelsonResults} from "./YoonNelsonResults";
+import React from "react";
+import {appColors} from "../../../common/styles";
+import {MODEL_TYPES} from "../../../common/constants";
+
+export const ModelResults = ({inputValues, responses, onClick, modelType}) => {
+  const colors = [appColors.primary, appColors.red, appColors.green];
+
+  const components = {
+    [MODEL_TYPES.THOMAS]: ThomasResults,
+    [MODEL_TYPES.ADAMS_BOHART]: AdamsBohartResults,
+    [MODEL_TYPES.YOON_NELSON]: YoonNelsonResults,
+  };
+  const ResultComponent = components[modelType];
+  return (
+    <ResultComponent
+      inputValues={inputValues}
+      responses={responses}
+      onClick={onClick}
+      colors={colors}
+    />
+  );
+};

--- a/src/components/ChemicalModels/Results/ThomasResults.jsx
+++ b/src/components/ChemicalModels/Results/ThomasResults.jsx
@@ -1,0 +1,51 @@
+import {Results} from "../Models/Results";
+import {ThomasInputFields} from "../Models/ThomasInputFields";
+import {ButtonWrapper, DataFrame, Title} from "../Models/ModelsStyles";
+import {ThomasResultFields} from "../Models/ThomasResultFields";
+import {ThomasModelPlot} from "../Models/Plots/ThomasModelPlot";
+import {Button} from "../../Button/Button";
+import React from "react";
+import {generateEquation, thomasCoefficients} from "../Models/equations";
+
+const thomasEquation = (data) => {
+  const template = "$$\\frac{C}{C0} = \\frac{1}{1 + e^{first-secondV_{ef}}}$$";
+  return generateEquation(template, thomasCoefficients(data));
+};
+
+export const ThomasResults = ({inputValues, responses, colors, onClick}) => {
+  return (
+    <>
+      <Results
+        inputFields={
+          <ThomasInputFields
+            F={inputValues.caudalVolumetrico}
+            C0={inputValues.concentracionInicial}
+            W={inputValues.sorbenteReactor}
+          />
+        }
+        resultsInfo={responses.map((response, index) => (
+          <DataFrame key={index}>
+            <Title color={colors[index % colors.length]}>
+              Resultados gráfico {++index}
+            </Title>
+            <ThomasResultFields
+              kth={response.Kth}
+              q0={response.q0}
+              R2={response.R2}
+              equation={thomasEquation(response)}
+            />
+          </DataFrame>
+        ))}
+        plot={
+          <ThomasModelPlot
+            points={responses.map((response) => response.points)}
+            expressions={responses}
+          />
+        }
+      />
+      <ButtonWrapper>
+        <Button size="medium" text="Volver a graficar" onClick={onClick} />
+      </ButtonWrapper>
+    </>
+  );
+};

--- a/src/components/ChemicalModels/Results/ThomasResults.jsx
+++ b/src/components/ChemicalModels/Results/ThomasResults.jsx
@@ -1,9 +1,8 @@
 import {Results} from "../Models/Results";
 import {ThomasInputFields} from "../Models/ThomasInputFields";
-import {ButtonWrapper, DataFrame, Title} from "../Models/ModelsStyles";
+import {DataFrame, Title} from "../Models/ModelsStyles";
 import {ThomasResultFields} from "../Models/ThomasResultFields";
 import {ThomasModelPlot} from "../Models/Plots/ThomasModelPlot";
-import {Button} from "../../Button/Button";
 import React from "react";
 import {generateEquation, thomasCoefficients} from "../Models/equations";
 
@@ -12,40 +11,35 @@ const thomasEquation = (data) => {
   return generateEquation(template, thomasCoefficients(data));
 };
 
-export const ThomasResults = ({inputValues, responses, colors, onClick}) => {
+export const ThomasResults = ({inputValues, responses, colors}) => {
   return (
-    <>
-      <Results
-        inputFields={
-          <ThomasInputFields
-            F={inputValues.caudalVolumetrico}
-            C0={inputValues.concentracionInicial}
-            W={inputValues.sorbenteReactor}
+    <Results
+      inputFields={
+        <ThomasInputFields
+          F={inputValues.caudalVolumetrico}
+          C0={inputValues.concentracionInicial}
+          W={inputValues.sorbenteReactor}
+        />
+      }
+      resultsInfo={responses.map((response, index) => (
+        <DataFrame key={index}>
+          <Title color={colors[index % colors.length]}>
+            Resultados gráfico {++index}
+          </Title>
+          <ThomasResultFields
+            kth={response.Kth}
+            q0={response.q0}
+            R2={response.R2}
+            equation={thomasEquation(response)}
           />
-        }
-        resultsInfo={responses.map((response, index) => (
-          <DataFrame key={index}>
-            <Title color={colors[index % colors.length]}>
-              Resultados gráfico {++index}
-            </Title>
-            <ThomasResultFields
-              kth={response.Kth}
-              q0={response.q0}
-              R2={response.R2}
-              equation={thomasEquation(response)}
-            />
-          </DataFrame>
-        ))}
-        plot={
-          <ThomasModelPlot
-            points={responses.map((response) => response.points)}
-            expressions={responses}
-          />
-        }
-      />
-      <ButtonWrapper>
-        <Button size="medium" text="Volver a graficar" onClick={onClick} />
-      </ButtonWrapper>
-    </>
+        </DataFrame>
+      ))}
+      plot={
+        <ThomasModelPlot
+          points={responses.map((response) => response.points)}
+          expressions={responses}
+        />
+      }
+    />
   );
 };

--- a/src/components/ChemicalModels/Results/YoonNelsonResults.jsx
+++ b/src/components/ChemicalModels/Results/YoonNelsonResults.jsx
@@ -1,0 +1,53 @@
+import {Results} from "../Models/Results";
+import {YoonNelsonInputFields} from "../Models/YoonNelsonInputFields";
+import {ButtonWrapper, DataFrame, Title} from "../Models/ModelsStyles";
+import {YoonNelsonResultFields} from "../Models/YoonNelsonResultFields";
+import {YoonNelsonModelPlot} from "../Models/Plots/YoonNelsonModelPlot";
+import {Button} from "../../Button/Button";
+import React from "react";
+import {generateEquation, yoonNelsonCoefficients} from "../Models/equations";
+
+const yoonNelsonEquation = (data) => {
+  const exponential = "e^{firstV{ef}-second}";
+  const template = `$$\\frac{C}{C0} = \\frac{${exponential}}{1 + ${exponential}}$$`;
+  return generateEquation(template, yoonNelsonCoefficients(data));
+};
+
+export const YoonNelsonResults = ({
+  inputValues,
+  responses,
+  colors,
+  onClick,
+}) => {
+  return (
+    <>
+      <Results
+        inputFields={
+          <YoonNelsonInputFields F={inputValues.caudalVolumetrico} />
+        }
+        resultsInfo={responses.map((response, index) => (
+          <DataFrame key={index}>
+            <Title color={colors[index % colors.length]}>
+              Resultados gráfico {++index}
+            </Title>
+            <YoonNelsonResultFields
+              Kyn={response.Kyn}
+              t={response.t}
+              R2={response.R2}
+              equation={yoonNelsonEquation(response)}
+            />
+          </DataFrame>
+        ))}
+        plot={
+          <YoonNelsonModelPlot
+            points={responses.map((response) => response.points)}
+            expressions={responses}
+          />
+        }
+      />
+      <ButtonWrapper>
+        <Button size="medium" text="Volver a graficar" onClick={onClick} />
+      </ButtonWrapper>
+    </>
+  );
+};

--- a/src/components/ChemicalModels/Results/YoonNelsonResults.jsx
+++ b/src/components/ChemicalModels/Results/YoonNelsonResults.jsx
@@ -1,9 +1,8 @@
 import {Results} from "../Models/Results";
 import {YoonNelsonInputFields} from "../Models/YoonNelsonInputFields";
-import {ButtonWrapper, DataFrame, Title} from "../Models/ModelsStyles";
+import {DataFrame, Title} from "../Models/ModelsStyles";
 import {YoonNelsonResultFields} from "../Models/YoonNelsonResultFields";
 import {YoonNelsonModelPlot} from "../Models/Plots/YoonNelsonModelPlot";
-import {Button} from "../../Button/Button";
 import React from "react";
 import {generateEquation, yoonNelsonCoefficients} from "../Models/equations";
 
@@ -13,41 +12,29 @@ const yoonNelsonEquation = (data) => {
   return generateEquation(template, yoonNelsonCoefficients(data));
 };
 
-export const YoonNelsonResults = ({
-  inputValues,
-  responses,
-  colors,
-  onClick,
-}) => {
+export const YoonNelsonResults = ({inputValues, responses, colors}) => {
   return (
-    <>
-      <Results
-        inputFields={
-          <YoonNelsonInputFields F={inputValues.caudalVolumetrico} />
-        }
-        resultsInfo={responses.map((response, index) => (
-          <DataFrame key={index}>
-            <Title color={colors[index % colors.length]}>
-              Resultados gráfico {++index}
-            </Title>
-            <YoonNelsonResultFields
-              Kyn={response.Kyn}
-              t={response.t}
-              R2={response.R2}
-              equation={yoonNelsonEquation(response)}
-            />
-          </DataFrame>
-        ))}
-        plot={
-          <YoonNelsonModelPlot
-            points={responses.map((response) => response.points)}
-            expressions={responses}
+    <Results
+      inputFields={<YoonNelsonInputFields F={inputValues.caudalVolumetrico} />}
+      resultsInfo={responses.map((response, index) => (
+        <DataFrame key={index}>
+          <Title color={colors[index % colors.length]}>
+            Resultados gráfico {++index}
+          </Title>
+          <YoonNelsonResultFields
+            Kyn={response.Kyn}
+            t={response.t}
+            R2={response.R2}
+            equation={yoonNelsonEquation(response)}
           />
-        }
-      />
-      <ButtonWrapper>
-        <Button size="medium" text="Volver a graficar" onClick={onClick} />
-      </ButtonWrapper>
-    </>
+        </DataFrame>
+      ))}
+      plot={
+        <YoonNelsonModelPlot
+          points={responses.map((response) => response.points)}
+          expressions={responses}
+        />
+      }
+    />
   );
 };

--- a/src/routing/routes/AdamsBohartRoute.jsx
+++ b/src/routing/routes/AdamsBohartRoute.jsx
@@ -21,8 +21,8 @@ import {CircularProgress} from "@material-ui/core";
 import {HelpText} from "../../components/ChemicalModels/ChemicalModelStyles";
 import {settings} from "../../config/settings";
 import {InfoAdamsBohartModal} from "../../components/ChemicalModels/InfoModals/InfoAdamsBohartModal";
-import {appColors} from "../../common/styles";
-import {AdamsBohartResults} from "../../components/ChemicalModels/Results/AdamsBohartResults";
+import {ModelResults} from "../../components/ChemicalModels/Results/ModelResults";
+import {MODEL_TYPES} from "../../common/constants";
 
 const INITIAL_ERROR = {
   message: null,
@@ -81,7 +81,6 @@ export const AdamsBohartRoute = () => {
     }
     setShowLoader(false);
   };
-  const colors = [appColors.primary, appColors.red, appColors.green];
 
   return (
     <>
@@ -97,10 +96,10 @@ export const AdamsBohartRoute = () => {
       />
       <PageLayout>
         {responses.length > 0 && responses.length === files.length ? (
-          <AdamsBohartResults
+          <ModelResults
             inputValues={inputValues}
             responses={responses}
-            colors={colors}
+            modelType={MODEL_TYPES.ADAMS_BOHART}
             onClick={() => {
               setResponses([]);
               setNewFiles([]);

--- a/src/routing/routes/AdamsBohartRoute.jsx
+++ b/src/routing/routes/AdamsBohartRoute.jsx
@@ -9,42 +9,24 @@ import {
 } from "../../common/fields";
 import {
   PageLayout,
-  ButtonWrapper,
   FormContainer,
   ContentWrapper,
   TemplateHelpWrapper,
   LoaderWrapper,
 } from "../../components/ChemicalModels/Models/ModelsStyles";
-import {Results} from "../../components/ChemicalModels/Models/Results";
 import {ErrorModal} from "../../components/ChemicalModels/ErrorModal";
 import {FileUpload} from "../../components/ChemicalModels/FileUpload";
-import {Button} from "../../components/Button/Button";
 import {TemplateFileHelp} from "../../components/TemplateFileHelp/TemplateFileHelp";
 import {CircularProgress} from "@material-ui/core";
 import {HelpText} from "../../components/ChemicalModels/ChemicalModelStyles";
 import {settings} from "../../config/settings";
 import {InfoAdamsBohartModal} from "../../components/ChemicalModels/InfoModals/InfoAdamsBohartModal";
-import {AdamsBohartInputFields} from "../../components/ChemicalModels/Models/AdamsBohartInputFields";
-import {AdamsBohartModelPlot} from "../../components/ChemicalModels/Models/Plots/AdamsBohartModelPlot";
-import {
-  DataFrame,
-  Title,
-} from "../../components/ChemicalModels/Models/ModelsStyles";
-import {AdamsBohartResultFields} from "../../components/ChemicalModels/Models/AdamsBohartResultFields";
 import {appColors} from "../../common/styles";
-import {
-  adamsBohartCofficients,
-  generateEquation,
-} from "../../components/ChemicalModels/Models/equations";
+import {AdamsBohartResults} from "../../components/ChemicalModels/Results/AdamsBohartResults";
 
 const INITIAL_ERROR = {
   message: null,
   index: null,
-};
-
-const adamsEquation = (data) => {
-  const template = `$$\\frac{C}{C0} = e^{firstV_{ef}-second}$$`;
-  return generateEquation(template, adamsBohartCofficients(data));
 };
 
 export const AdamsBohartRoute = () => {
@@ -115,47 +97,15 @@ export const AdamsBohartRoute = () => {
       />
       <PageLayout>
         {responses.length > 0 && responses.length === files.length ? (
-          <>
-            <Results
-              inputFields={
-                <AdamsBohartInputFields
-                  F={inputValues.caudalVolumetrico}
-                  C0={inputValues.concentracionInicial}
-                  Z={inputValues.alturaLechoReactor}
-                  U0={inputValues.velocidadLineal}
-                />
-              }
-              resultsInfo={responses.map((response, index) => (
-                <DataFrame key={index}>
-                  <Title color={colors[index % colors.length]}>
-                    Resultados gráfico {++index}
-                  </Title>
-                  <AdamsBohartResultFields
-                    Kab={response.Kab}
-                    N0={response.N0}
-                    R2={response.R2}
-                    equation={adamsEquation(response)}
-                  />
-                </DataFrame>
-              ))}
-              plot={
-                <AdamsBohartModelPlot
-                  points={responses.map((response) => response.points)}
-                  expressions={responses}
-                />
-              }
-            />
-            <ButtonWrapper>
-              <Button
-                size="medium"
-                text="Volver a graficar"
-                onClick={() => {
-                  setResponses([]);
-                  setNewFiles([]);
-                }}
-              />
-            </ButtonWrapper>
-          </>
+          <AdamsBohartResults
+            inputValues={inputValues}
+            responses={responses}
+            colors={colors}
+            onClick={() => {
+              setResponses([]);
+              setNewFiles([]);
+            }}
+          />
         ) : (
           <>
             <HelpText>

--- a/src/routing/routes/ThomasRoute.jsx
+++ b/src/routing/routes/ThomasRoute.jsx
@@ -21,8 +21,8 @@ import {CircularProgress} from "@material-ui/core";
 import {HelpText} from "../../components/ChemicalModels/ChemicalModelStyles";
 import {settings} from "../../config/settings";
 import {InfoThomasModal} from "../../components/ChemicalModels/InfoModals/InfoThomasModal";
-import {appColors} from "../../common/styles";
-import {ThomasResults} from "../../components/ChemicalModels/Results/ThomasResults";
+import {ModelResults} from "../../components/ChemicalModels/Results/ModelResults";
+import {MODEL_TYPES} from "../../common/constants";
 
 const INITIAL_ERROR = {
   message: null,
@@ -80,7 +80,6 @@ export const ThomasRoute = () => {
     }
     setShowLoader(false);
   };
-  const colors = [appColors.primary, appColors.red, appColors.green];
 
   return (
     <>
@@ -96,10 +95,10 @@ export const ThomasRoute = () => {
       />
       <PageLayout>
         {responses.length > 0 && responses.length === files.length ? (
-          <ThomasResults
+          <ModelResults
             inputValues={inputValues}
             responses={responses}
-            colors={colors}
+            modelType={MODEL_TYPES.THOMAS}
             onClick={() => {
               setResponses([]);
               setNewFiles([]);

--- a/src/routing/routes/ThomasRoute.jsx
+++ b/src/routing/routes/ThomasRoute.jsx
@@ -9,42 +9,24 @@ import {
 } from "../../common/fields";
 import {
   PageLayout,
-  ButtonWrapper,
   FormContainer,
   ContentWrapper,
   TemplateHelpWrapper,
   LoaderWrapper,
 } from "../../components/ChemicalModels/Models/ModelsStyles";
-import {Results} from "../../components/ChemicalModels/Models/Results";
 import {ErrorModal} from "../../components/ChemicalModels/ErrorModal";
 import {FileUpload} from "../../components/ChemicalModels/FileUpload";
-import {Button} from "../../components/Button/Button";
 import {TemplateFileHelp} from "../../components/TemplateFileHelp/TemplateFileHelp";
 import {CircularProgress} from "@material-ui/core";
 import {HelpText} from "../../components/ChemicalModels/ChemicalModelStyles";
 import {settings} from "../../config/settings";
 import {InfoThomasModal} from "../../components/ChemicalModels/InfoModals/InfoThomasModal";
-import {ThomasInputFields} from "../../components/ChemicalModels/Models/ThomasInputFields";
-import {ThomasModelPlot} from "../../components/ChemicalModels/Models/Plots/ThomasModelPlot";
-import {
-  DataFrame,
-  Title,
-} from "../../components/ChemicalModels/Models/ModelsStyles";
-import {ThomasResultFields} from "../../components/ChemicalModels/Models/ThomasResultFields";
 import {appColors} from "../../common/styles";
-import {
-  generateEquation,
-  thomasCoefficients,
-} from "../../components/ChemicalModels/Models/equations";
+import {ThomasResults} from "../../components/ChemicalModels/Results/ThomasResults";
 
 const INITIAL_ERROR = {
   message: null,
   index: null,
-};
-
-const thomasEquation = (data) => {
-  const template = "$$\\frac{C}{C0} = \\frac{1}{1 + e^{first-secondV_{ef}}}$$";
-  return generateEquation(template, thomasCoefficients(data));
 };
 
 export const ThomasRoute = () => {
@@ -114,46 +96,15 @@ export const ThomasRoute = () => {
       />
       <PageLayout>
         {responses.length > 0 && responses.length === files.length ? (
-          <>
-            <Results
-              inputFields={
-                <ThomasInputFields
-                  F={inputValues.caudalVolumetrico}
-                  C0={inputValues.concentracionInicial}
-                  W={inputValues.sorbenteReactor}
-                />
-              }
-              resultsInfo={responses.map((response, index) => (
-                <DataFrame key={index}>
-                  <Title color={colors[index % colors.length]}>
-                    Resultados gráfico {++index}
-                  </Title>
-                  <ThomasResultFields
-                    kth={response.Kth}
-                    q0={response.q0}
-                    R2={response.R2}
-                    equation={thomasEquation(response)}
-                  />
-                </DataFrame>
-              ))}
-              plot={
-                <ThomasModelPlot
-                  points={responses.map((response) => response.points)}
-                  expressions={responses}
-                />
-              }
-            />
-            <ButtonWrapper>
-              <Button
-                size="medium"
-                text="Volver a graficar"
-                onClick={() => {
-                  setResponses([]);
-                  setNewFiles([]);
-                }}
-              />
-            </ButtonWrapper>
-          </>
+          <ThomasResults
+            inputValues={inputValues}
+            responses={responses}
+            colors={colors}
+            onClick={() => {
+              setResponses([]);
+              setNewFiles([]);
+            }}
+          />
         ) : (
           <>
             <HelpText>

--- a/src/routing/routes/YoonNelsonRoute.jsx
+++ b/src/routing/routes/YoonNelsonRoute.jsx
@@ -9,43 +9,24 @@ import {
 } from "../../common/fields";
 import {
   PageLayout,
-  ButtonWrapper,
   FormContainer,
   ContentWrapper,
   TemplateHelpWrapper,
   LoaderWrapper,
 } from "../../components/ChemicalModels/Models/ModelsStyles";
-import {Results} from "../../components/ChemicalModels/Models/Results";
 import {ErrorModal} from "../../components/ChemicalModels/ErrorModal";
 import {FileUpload} from "../../components/ChemicalModels/FileUpload";
-import {Button} from "../../components/Button/Button";
 import {TemplateFileHelp} from "../../components/TemplateFileHelp/TemplateFileHelp";
 import {CircularProgress} from "@material-ui/core";
 import {HelpText} from "../../components/ChemicalModels/ChemicalModelStyles";
 import {settings} from "../../config/settings";
-import {YoonNelsonInputFields} from "../../components/ChemicalModels/Models/YoonNelsonInputFields.jsx";
-import {YoonNelsonModelPlot} from "../../components/ChemicalModels/Models/Plots/YoonNelsonModelPlot";
-import {
-  DataFrame,
-  Title,
-} from "../../components/ChemicalModels/Models/ModelsStyles";
-import {YoonNelsonResultFields} from "../../components/ChemicalModels/Models/YoonNelsonResultFields";
 import {appColors} from "../../common/styles";
-import {
-  generateEquation,
-  yoonNelsonCoefficients,
-} from "../../components/ChemicalModels/Models/equations";
 import {InfoYoonNelsonModal} from "../../components/ChemicalModels/InfoModals/InfoYoonNelsonModal";
+import {YoonNelsonResults} from "../../components/ChemicalModels/Results/YoonNelsonResults";
 
 const INITIAL_ERROR = {
   message: null,
   index: null,
-};
-
-const yoonNelsonEquation = (data) => {
-  const exponential = "e^{firstV{ef}-second}";
-  const template = `$$\\frac{C}{C0} = \\frac{${exponential}}{1 + ${exponential}}$$`;
-  return generateEquation(template, yoonNelsonCoefficients(data));
 };
 
 export const YoonNelsonRoute = () => {
@@ -113,42 +94,15 @@ export const YoonNelsonRoute = () => {
       />
       <PageLayout>
         {responses.length > 0 && responses.length === files.length ? (
-          <>
-            <Results
-              inputFields={
-                <YoonNelsonInputFields F={inputValues.caudalVolumetrico} />
-              }
-              resultsInfo={responses.map((response, index) => (
-                <DataFrame key={index}>
-                  <Title color={colors[index % colors.length]}>
-                    Resultados gráfico {++index}
-                  </Title>
-                  <YoonNelsonResultFields
-                    Kyn={response.Kyn}
-                    t={response.t}
-                    R2={response.R2}
-                    equation={yoonNelsonEquation(response)}
-                  />
-                </DataFrame>
-              ))}
-              plot={
-                <YoonNelsonModelPlot
-                  points={responses.map((response) => response.points)}
-                  expressions={responses}
-                />
-              }
-            />
-            <ButtonWrapper>
-              <Button
-                size="medium"
-                text="Volver a graficar"
-                onClick={() => {
-                  setResponses([]);
-                  setNewFiles([]);
-                }}
-              />
-            </ButtonWrapper>
-          </>
+          <YoonNelsonResults
+            inputValues={inputValues}
+            responses={responses}
+            colors={colors}
+            onClick={() => {
+              setResponses([]);
+              setNewFiles([]);
+            }}
+          />
         ) : (
           <>
             <HelpText>

--- a/src/routing/routes/YoonNelsonRoute.jsx
+++ b/src/routing/routes/YoonNelsonRoute.jsx
@@ -20,9 +20,9 @@ import {TemplateFileHelp} from "../../components/TemplateFileHelp/TemplateFileHe
 import {CircularProgress} from "@material-ui/core";
 import {HelpText} from "../../components/ChemicalModels/ChemicalModelStyles";
 import {settings} from "../../config/settings";
-import {appColors} from "../../common/styles";
 import {InfoYoonNelsonModal} from "../../components/ChemicalModels/InfoModals/InfoYoonNelsonModal";
-import {YoonNelsonResults} from "../../components/ChemicalModels/Results/YoonNelsonResults";
+import {ModelResults} from "../../components/ChemicalModels/Results/ModelResults";
+import {MODEL_TYPES} from "../../common/constants";
 
 const INITIAL_ERROR = {
   message: null,
@@ -78,7 +78,6 @@ export const YoonNelsonRoute = () => {
     }
     setShowLoader(false);
   };
-  const colors = [appColors.primary, appColors.red, appColors.green];
 
   return (
     <>
@@ -94,10 +93,10 @@ export const YoonNelsonRoute = () => {
       />
       <PageLayout>
         {responses.length > 0 && responses.length === files.length ? (
-          <YoonNelsonResults
+          <ModelResults
+            modelType={MODEL_TYPES.YOON_NELSON}
             inputValues={inputValues}
             responses={responses}
-            colors={colors}
             onClick={() => {
               setResponses([]);
               setNewFiles([]);


### PR DESCRIPTION
Closes #233 

Refactor para reducir (pero no eliminar completamente) la cantidad de código duplicado, y facilitar la reutilización de la vista de resultados

La clave está en el componente ModelResults que hace un "dispatch" a los distintos resultados según qué tipo de modelo es.